### PR TITLE
feat: Add full support for Trojan protocol

### DIFF
--- a/internal/api/handlers/v2ray.go
+++ b/internal/api/handlers/v2ray.go
@@ -43,6 +43,13 @@ type ShadowsocksConfigData struct {
 	Method     string `json:"method"`
 }
 
+// TrojanConfigData is a struct for validating the basic fields of a Trojan config.
+type TrojanConfigData struct {
+	Server     string `json:"server"`
+	ServerPort int    `json:"server_port"`
+	Password   string `json:"password"`
+}
+
 // CreateConfig is the handler for creating a new V2Ray configuration.
 func CreateConfig(c *gin.Context) {
 	var payload CreateConfigPayload
@@ -81,6 +88,16 @@ func CreateConfig(c *gin.Context) {
 		}
 		if ssData.Server == "" || ssData.ServerPort == 0 || ssData.Password == "" || ssData.Method == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Shadowsocks config_data must contain 'server', 'server_port', 'password', and 'method' fields"})
+			return
+		}
+	case "trojan":
+		var trojanData TrojanConfigData
+		if err := json.Unmarshal(payload.ConfigData, &trojanData); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Trojan config_data format"})
+			return
+		}
+		if trojanData.Server == "" || trojanData.ServerPort == 0 || trojanData.Password == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Trojan config_data must contain 'server', 'server_port', and 'password' fields"})
 			return
 		}
 	default:
@@ -250,6 +267,16 @@ func UpdateConfig(c *gin.Context) {
 			}
 			if ssData.Server == "" || ssData.ServerPort == 0 || ssData.Password == "" || ssData.Method == "" {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Shadowsocks config_data must contain 'server', 'server_port', 'password', and 'method' fields"})
+				return
+			}
+		case "trojan":
+			var trojanData TrojanConfigData
+			if err := json.Unmarshal(*payload.ConfigData, &trojanData); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Trojan config_data format"})
+				return
+			}
+			if trojanData.Server == "" || trojanData.ServerPort == 0 || trojanData.Password == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Trojan config_data must contain 'server', 'server_port', and 'password' fields"})
 				return
 			}
 		}

--- a/internal/api/handlers/v2ray_test.go
+++ b/internal/api/handlers/v2ray_test.go
@@ -263,6 +263,29 @@ func TestVlessConfig(t *testing.T) {
 	})
 }
 
+func TestTrojanConfig(t *testing.T) {
+	accessToken, _ := loginAs(t, "user1", "password123")
+
+	t.Run("Create Trojan Config - Success", func(t *testing.T) {
+		configPayload := `{"name": "My Trojan Server", "protocol": "trojan", "config_data": {"server": "trojan.server.com", "server_port": 443, "password": "trojan-password"}}`
+		req, _ := http.NewRequest(http.MethodPost, "/api/v1/configs", bytes.NewBufferString(configPayload))
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		w := httptest.NewRecorder()
+		testRouter.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusCreated, w.Code)
+	})
+
+	t.Run("Create Trojan Config - Invalid Data", func(t *testing.T) {
+		// Missing 'password' field
+		configPayload := `{"name": "My Invalid Trojan", "protocol": "trojan", "config_data": {"server": "trojan.server.com", "server_port": 443}}`
+		req, _ := http.NewRequest(http.MethodPost, "/api/v1/configs", bytes.NewBufferString(configPayload))
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		w := httptest.NewRecorder()
+		testRouter.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
 func TestShadowsocksConfig(t *testing.T) {
 	accessToken, _ := loginAs(t, "user1", "password123")
 

--- a/web/src/components/config/ConfigEditor.vue
+++ b/web/src/components/config/ConfigEditor.vue
@@ -23,6 +23,7 @@
                     <option value="vmess">VMess</option>
                     <option value="vless">VLESS</option>
                     <option value="shadowsocks">Shadowsocks</option>
+                    <option value="trojan">Trojan</option>
                   </select>
                 </div>
 
@@ -86,6 +87,22 @@
                   </div>
                 </template>
 
+                <!-- Trojan Fields -->
+                <template v-if="form.protocol === 'trojan'">
+                   <div>
+                    <label for="trojan-server" class="block text-sm font-medium text-gray-700">Server Address</label>
+                    <input v-model="form.config_data.server" type="text" id="trojan-server" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3" required />
+                  </div>
+                  <div>
+                    <label for="trojan-port" class="block text-sm font-medium text-gray-700">Server Port</label>
+                    <input v-model.number="form.config_data.server_port" type="number" id="trojan-port" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3" required />
+                  </div>
+                   <div>
+                    <label for="trojan-password" class="block text-sm font-medium text-gray-700">Password</label>
+                    <input v-model="form.config_data.password" type="password" id="trojan-password" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3" required />
+                  </div>
+                </template>
+
                 <div class="mt-6 flex justify-end space-x-2">
                   <button type="button" @click="closeModal" class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200 focus:outline-none">
                     Cancel
@@ -130,6 +147,10 @@ const defaultShadowsocksData = () => ({
   server: '', server_port: 8388, password: '', method: 'aes-256-gcm'
 })
 
+const defaultTrojanData = () => ({
+  server: '', server_port: 443, password: ''
+})
+
 const form = ref<ConfigPayload>({
   name: '',
   protocol: 'vmess',
@@ -164,6 +185,8 @@ const onProtocolChange = () => {
     form.value.config_data = defaultVlessData()
   } else if (form.value.protocol === 'shadowsocks') {
     form.value.config_data = defaultShadowsocksData()
+  } else if (form.value.protocol === 'trojan') {
+    form.value.config_data = defaultTrojanData()
   }
 }
 </script>


### PR DESCRIPTION
This commit introduces full support for the Trojan protocol across the system.

Backend:
- Added a `TrojanConfigData` struct to `internal/api/handlers/v2ray.go`.
- Implemented validation logic for Trojan configurations in the `CreateConfig` and `UpdateConfig` functions.

Backend Test:
- Added `TestTrojanConfig` to `internal/api/handlers/v2ray_test.go` to verify the new backend logic, including success and failure cases.

Frontend:
- Updated `web/src/components/config/ConfigEditor.vue` to include 'Trojan' in the protocol selector.
- Added dynamic form fields for Trojan-specific settings (server, port, password).
- Implemented the necessary data handling logic in the Vue component.