### PR TITLE
feat: Add backend for monitoring page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/api/handlers/metrics.go
+++ b/internal/api/handlers/metrics.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"k2ray/internal/system"
+	"net/http"
+)
+
+// GetTrafficMetrics handles the request for traffic metrics.
+func GetTrafficMetrics(c *gin.Context) {
+	metrics := system.GetTrafficMetrics()
+	c.JSON(http.StatusOK, metrics)
+}
+
+// GetConnectionMetrics handles the request for connection metrics.
+func GetConnectionMetrics(c *gin.Context) {
+	metrics := system.GetConnectionMetrics()
+	c.JSON(http.StatusOK, metrics)
+}
+
+// GetPerformanceMetrics handles the request for performance metrics.
+func GetPerformanceMetrics(c *gin.Context) {
+	metrics := system.GetPerformanceMetrics()
+	c.JSON(http.StatusOK, metrics)
+}

--- a/internal/api/handlers/websocket.go
+++ b/internal/api/handlers/websocket.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"log"
+	"net/http"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		// Allow all connections by default.
+		// In a production environment, you might want to restrict this.
+		return true
+	},
+}
+
+// WebSocketHandler handles the WebSocket connection.
+func WebSocketHandler(c *gin.Context) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("Failed to set websocket upgrade: %+v", err)
+		return
+	}
+	defer conn.Close()
+
+	log.Println("WebSocket connection established.")
+
+	// This is a simple loop to demonstrate sending messages.
+	// In a real application, you would have a more sophisticated message handling system.
+	for {
+		// Send a test message
+		message := map[string]string{"message": "This is a test message from the WebSocket server."}
+		if err := conn.WriteJSON(message); err != nil {
+			log.Printf("Error sending message: %v", err)
+			break
+		}
+
+		// In a real application, you'd likely have a select statement here
+		// to handle incoming messages, tickers for periodic messages, and a done channel.
+		// For this task, we'll just send one message and then read to keep the connection open.
+
+		// Wait for a message from the client (or for the connection to close)
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			log.Printf("WebSocket connection closed: %v", err)
+			break
+		}
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -59,6 +59,17 @@ func SetupRouter(router *gin.Engine) {
 				v2rayRoutes.POST("/stop", handlers.StopV2Ray)
 				v2rayRoutes.GET("/status", handlers.GetV2RayStatus)
 			}
+
+			// Metrics routes
+			metricsRoutes := protected.Group("/metrics")
+			{
+				metricsRoutes.GET("/traffic", handlers.GetTrafficMetrics)
+				metricsRoutes.GET("/connections", handlers.GetConnectionMetrics)
+				metricsRoutes.GET("/performance", handlers.GetPerformanceMetrics)
+			}
+
+			// WebSocket route
+			protected.GET("/ws", handlers.WebSocketHandler)
 		}
 	}
 }

--- a/internal/system/metrics.go
+++ b/internal/system/metrics.go
@@ -1,0 +1,54 @@
+package system
+
+import (
+	"math/rand"
+	"time"
+)
+
+// TrafficMetrics represents traffic data.
+type TrafficMetrics struct {
+	Uplink   int64 `json:"uplink"`
+	Downlink int64 `json:"downlink"`
+}
+
+// ConnectionMetrics represents connection data.
+type ConnectionMetrics struct {
+	Active   int `json:"active"`
+	Total    int `json:"total"`
+	Failures int `json:"failures"`
+}
+
+// PerformanceMetrics represents system performance data.
+type PerformanceMetrics struct {
+	CPUUsage    float64 `json:"cpu_usage"`
+	MemoryUsage float64 `json:"memory_usage"`
+}
+
+// GetTrafficMetrics generates mock traffic metrics.
+func GetTrafficMetrics() *TrafficMetrics {
+	return &TrafficMetrics{
+		Uplink:   rand.Int63n(100000),
+		Downlink: rand.Int63n(1000000),
+	}
+}
+
+// GetConnectionMetrics generates mock connection metrics.
+func GetConnectionMetrics() *ConnectionMetrics {
+	return &ConnectionMetrics{
+		Active:   rand.Intn(100),
+		Total:    rand.Intn(1000),
+		Failures: rand.Intn(10),
+	}
+}
+
+// GetPerformanceMetrics generates mock performance metrics.
+func GetPerformanceMetrics() *PerformanceMetrics {
+	return &PerformanceMetrics{
+		CPUUsage:    rand.Float64() * 100,
+		MemoryUsage: rand.Float64() * 100,
+	}
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}


### PR DESCRIPTION
This commit introduces the backend infrastructure for the monitoring page.

It includes:
- API endpoints for metrics:
  - `/api/v1/metrics/traffic`
  - `/api/v1/metrics/connections`
  - `/api/v1/metrics/performance` These endpoints currently return mock data.
- A WebSocket endpoint at `/api/v1/ws` for real-time updates.
- A new service layer in `internal/system/metrics.go` to provide the data.

This lays the foundation for the frontend to be able to display system metrics and receive real-time updates.